### PR TITLE
[PR] V2, Change method to proxy and redesign

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ npm install --save sequelize-use-cache
 
 ## Usage
 ### Usable methods
-findOne, findAll, count, max, min, sum, findByPk, findAndCountAll
+All select queries
 
 ### parameter
 ```js
@@ -46,13 +46,13 @@ projects.findAll({
   cache: true,
   expire: 5,
 })
-console.log(projects.cacheHit) // false
+console.log(sequelize.cacheHit) // false
 
 projects.findAll({
   cache: true,
   expire: 5,
 })
-console.log(projects.cacheHit) // true
+console.log(sequelize.cacheHit) // true
 ```
 
 ## License

--- a/__test__/integration.test.js
+++ b/__test__/integration.test.js
@@ -88,7 +88,7 @@ describe('Integration test', () => {
           title: 'bar',
         },
       })
-      expect(projects.cacheHit).toEqual(undefined)
+      expect(sequelize.cacheHit).toEqual(undefined)
     })
 
     test('findAll', async () => {
@@ -101,7 +101,7 @@ describe('Integration test', () => {
         cache: true,
         expire: 5,
       })
-      expect(projects.cacheHit).toEqual(false)
+      expect(sequelize.cacheHit).toEqual(false)
 
       await projects.findAll({
         where: {
@@ -110,7 +110,7 @@ describe('Integration test', () => {
         cache: true,
         expire: 5,
       })
-      expect(projects.cacheHit).toEqual(true)
+      expect(sequelize.cacheHit).toEqual(true)
     })
 
     test('findOne(with raw)', async () => {
@@ -124,7 +124,7 @@ describe('Integration test', () => {
         cache: true,
         expire: 5,
       })
-      expect(projects.cacheHit).toEqual(false)
+      expect(sequelize.cacheHit).toEqual(false)
 
       await projects.findOne({
         where: {
@@ -134,64 +134,7 @@ describe('Integration test', () => {
         cache: true,
         expire: 5,
       })
-      expect(projects.cacheHit).toEqual(true)
-    })
-
-    test('min', async () => {
-      const { projects } = sequelize.models
-
-      const fromDB = await projects.min('id', {
-        cache: true,
-        expire: 5,
-      })
-      expect(projects.cacheHit).toEqual(false)
-
-      const fromCache = await projects.min('id', {
-        cache: true,
-        expire: 5,
-      })
-
-      expect(fromDB).toEqual(fromCache)
-      expect(fromCache).toEqual(1)
-      expect(projects.cacheHit).toEqual(true)
-    })
-
-    test('max', async () => {
-      const { projects } = sequelize.models
-
-      const fromDB = await projects.max('id', {
-        cache: true,
-        expire: 5,
-      })
-      expect(projects.cacheHit).toEqual(false)
-
-      const fromCache = await projects.max('id', {
-        cache: true,
-        expire: 5,
-      })
-
-      expect(fromDB).toEqual(fromCache)
-      expect(fromCache).toEqual(2)
-      expect(projects.cacheHit).toEqual(true)
-    })
-
-    test('sum', async () => {
-      const { projects } = sequelize.models
-
-      const fromDB = await projects.sum('id', {
-        cache: true,
-        expire: 5,
-      })
-      expect(projects.cacheHit).toEqual(false)
-
-      const fromCache = await projects.sum('id', {
-        cache: true,
-        expire: 5,
-      })
-
-      expect(fromDB).toEqual(fromCache)
-      expect(fromCache).toEqual(3)
-      expect(projects.cacheHit).toEqual(true)
+      expect(sequelize.cacheHit).toEqual(true)
     })
 
     test('count', async () => {
@@ -201,7 +144,7 @@ describe('Integration test', () => {
         cache: true,
         expire: 5,
       })
-      expect(projects.cacheHit).toEqual(false)
+      expect(sequelize.cacheHit).toEqual(false)
 
       const fromCache = await projects.count({
         cache: true,
@@ -210,7 +153,64 @@ describe('Integration test', () => {
 
       expect(fromDB).toEqual(fromCache)
       expect(fromCache).toEqual(2)
-      expect(projects.cacheHit).toEqual(true)
+      expect(sequelize.cacheHit).toEqual(true)
+    })
+
+    test('min', async () => {
+      const { projects } = sequelize.models
+
+      const fromDB = await projects.min('id', {
+        cache: true,
+        expire: 5,
+      })
+      expect(sequelize.cacheHit).toEqual(false)
+
+      const fromCache = await projects.min('id', {
+        cache: true,
+        expire: 5,
+      })
+
+      expect(fromDB).toEqual(fromCache)
+      expect(fromCache).toEqual(1)
+      expect(sequelize.cacheHit).toEqual(true)
+    })
+
+    test('max', async () => {
+      const { projects } = sequelize.models
+
+      const fromDB = await projects.max('id', {
+        cache: true,
+        expire: 5,
+      })
+      expect(sequelize.cacheHit).toEqual(false)
+
+      const fromCache = await projects.max('id', {
+        cache: true,
+        expire: 5,
+      })
+
+      expect(fromDB).toEqual(fromCache)
+      expect(fromCache).toEqual(2)
+      expect(sequelize.cacheHit).toEqual(true)
+    })
+
+    test('sum', async () => {
+      const { projects } = sequelize.models
+
+      const fromDB = await projects.sum('id', {
+        cache: true,
+        expire: 5,
+      })
+      expect(sequelize.cacheHit).toEqual(false)
+
+      const fromCache = await projects.sum('id', {
+        cache: true,
+        expire: 5,
+      })
+
+      expect(fromDB).toEqual(fromCache)
+      expect(fromCache).toEqual(3)
+      expect(sequelize.cacheHit).toEqual(true)
     })
   })
   describe('with include', () => {
@@ -227,7 +227,7 @@ describe('Integration test', () => {
         cache: true,
         expire: 5,
       })
-      expect(users.cacheHit).toEqual(false)
+      expect(sequelize.cacheHit).toEqual(false)
 
 
       await users.findOne({
@@ -241,7 +241,7 @@ describe('Integration test', () => {
         expire: 5,
       })
 
-      expect(users.cacheHit).toEqual(true)
+      expect(sequelize.cacheHit).toEqual(true)
     })
 
     test('with include(with raw)', async () => {
@@ -258,7 +258,7 @@ describe('Integration test', () => {
         cache: true,
         expire: 5,
       })
-      expect(users.cacheHit).toEqual(false)
+      expect(sequelize.cacheHit).toEqual(false)
 
       await users.findAll({
         where: {
@@ -271,7 +271,33 @@ describe('Integration test', () => {
         cache: true,
         expire: 5,
       })
-      expect(users.cacheHit).toEqual(true)
+      expect(sequelize.cacheHit).toEqual(true)
+    })
+  })
+
+  describe('with attributes', () => {
+    test('with attributes', async () => {
+      const { projects } = sequelize.models
+
+      await projects.findAll({
+        attributes: {
+          exclude: ['id'],
+        },
+        cache: true,
+        expire: 5
+      })
+
+      expect(sequelize.cacheHit).toEqual(false)
+
+      await projects.findAll({
+        attributes: {
+          exclude: ['id'],
+        },
+        cache: true,
+        expire: 5
+      })
+
+      expect(sequelize.cacheHit).toEqual(true)
     })
   })
 })

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,41 +7,15 @@ exports.default = useCache;
 
 var _util = require("util");
 
-var _sequelize = _interopRequireDefault(require("sequelize"));
-
 var _crypto = _interopRequireDefault(require("crypto"));
 
-var _lodash = _interopRequireDefault(require("lodash.clonedeep"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
-const methods = {
-  findOne: {
-    optionsIdx: 0
-  },
-  findAll: {
-    optionsIdx: 0
-  },
-  max: {
-    optionsIdx: 1
-  },
-  min: {
-    optionsIdx: 1
-  },
-  sum: {
-    optionsIdx: 1
-  },
-  count: {
-    optionsIdx: 0
-  } // findAndCountAll === findAll + count
-  // findByPk === findOne
-
-};
 
 function useCache(sequelize, redis) {
   const asyncRedisGet = (0, _util.promisify)(redis.get).bind(redis);
   const asyncRedisSet = (0, _util.promisify)(redis.set).bind(redis);
-  const queryGenerator = sequelize.getQueryInterface().QueryGenerator;
+  const SELECT = 'SELECT';
+  const originalQueryMethod = sequelize.query.bind(sequelize);
 
   const getFromCache = async (key, model, {
     raw
@@ -77,82 +51,44 @@ function useCache(sequelize, redis) {
     await asyncRedisSet(...redisArgs);
   };
 
-  const fetchFromDatabase = async (key, method, ...args) => {
-    const results = await method(...args);
-    const options = args[0];
+  const fetchFromDatabase = async (key, sql, options) => {
+    const results = await originalQueryMethod(sql, options);
     setCache(key, results, options);
     return results;
   };
 
-  const generateSelectQuery = (model, options) => {
-    if (options.include) {
-      if (!Array.isArray(options.include)) {
-        options.include = [options.include];
-      }
+  const keyPrefix = 'sequelize-use-cache';
 
-      const tableNames = {};
-      tableNames[model.getTableName(options)] = true;
-      options.hasJoin = true;
+  const generateKey = (sql, model) => {
+    const tableName = model && model.tableName || '';
 
-      model._validateIncludedElements(options, tableNames);
-    }
+    const hash = _crypto.default.createHash('sha256').update(sql).digest('hex');
 
-    _sequelize.default.Utils.mapFinderOptions(options, model);
-
-    return queryGenerator.selectQuery(model.tableName, options, model);
+    return `${keyPrefix}:${tableName}:${hash}`;
   };
 
-  const keyPrefix = 'sequelize-redis';
-
-  const generateKey = ({
-    model,
-    method,
-    options
-  }) => {
-    const stmt = generateSelectQuery(model, (0, _lodash.default)(options));
-    const tableName = model.tableName;
-
-    const hash = _crypto.default.createHash('sha256').update(stmt).digest('hex');
-
-    return `${keyPrefix}:${tableName}:${method.name}:${hash}`;
-  };
-
-  const fetchFromCache = async (model, method, ...args) => {
-    const options = args[0];
-    const key = generateKey({
-      model,
-      method,
-      options
-    });
+  const fetchFromCache = async (sql, options) => {
+    const {
+      model
+    } = options;
+    const key = generateKey(sql, model);
     const res = await getFromCache(key, model, options);
 
     if (res) {
-      model.cacheHit = true;
+      sequelize.cacheHit = true;
       return res;
     }
 
-    model.cacheHit = false;
-    return await fetchFromDatabase(key, method, ...args);
+    sequelize.cacheHit = false;
+    return await fetchFromDatabase(key, sql, options);
   };
 
-  const modelNames = Object.keys(sequelize.models);
-  modelNames.forEach(modelName => {
-    const model = sequelize.models[modelName];
-    Object.entries(methods).map(([method, {
-      optionsIdx
-    }]) => {
-      const originalMethod = model[method].bind(model);
+  sequelize.query = async (sql, options) => {
+    if (options.type === SELECT && options.cache) {
+      return await fetchFromCache(sql, options);
+    }
 
-      model[method] = async (...args) => {
-        const options = args[optionsIdx];
-
-        if (options && options.cache) {
-          return await fetchFromCache(model, originalMethod, ...args);
-        }
-
-        model.cacheHit = undefined;
-        return await originalMethod(...args);
-      };
-    });
-  });
+    sequelize.cacheHit = undefined;
+    return await originalQueryMethod(sql, options);
+  };
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sequelize-use-cache",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1457,7 +1457,8 @@
     "@types/node": {
       "version": "14.0.13",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.13.tgz",
-      "integrity": "sha512-rouEWBImiRaSJsVA+ITTFM6ZxibuAlTuNOCyxVbwreu6k6+ujs7DfnU9o+PShFhET78pMBl3eH+AGSI5eOTkPA=="
+      "integrity": "sha512-rouEWBImiRaSJsVA+ITTFM6ZxibuAlTuNOCyxVbwreu6k6+ujs7DfnU9o+PShFhET78pMBl3eH+AGSI5eOTkPA==",
+      "dev": true
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -1615,7 +1616,8 @@
     "any-promise": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-      "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
+      "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8=",
+      "dev": true
     },
     "anymatch": {
       "version": "3.1.1",
@@ -1901,7 +1903,8 @@
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "dev": true
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -2260,6 +2263,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cls-bluebird/-/cls-bluebird-2.1.0.tgz",
       "integrity": "sha1-N+8eCAqP+1XC9BZPU28ZGeeWiu4=",
+      "dev": true,
       "requires": {
         "is-bluebird": "^1.0.2",
         "shimmer": "^1.1.0"
@@ -2457,6 +2461,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
       "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "dev": true,
       "requires": {
         "ms": "^2.1.1"
       }
@@ -2612,7 +2617,8 @@
     "dottie": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/dottie/-/dottie-2.0.2.tgz",
-      "integrity": "sha512-fmrwR04lsniq/uSr8yikThDTrM7epXHBAAjH9TbeH3rEA8tdCO7mRzB9hdmdGyJCxF8KERo9CITcm3kGuoyMhg=="
+      "integrity": "sha512-fmrwR04lsniq/uSr8yikThDTrM7epXHBAAjH9TbeH3rEA8tdCO7mRzB9hdmdGyJCxF8KERo9CITcm3kGuoyMhg==",
+      "dev": true
     },
     "ecc-jsbn": {
       "version": "0.1.2",
@@ -3610,7 +3616,8 @@
     "inflection": {
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/inflection/-/inflection-1.12.0.tgz",
-      "integrity": "sha1-ogCTVlbW9fa8TcdQLhrstwMihBY="
+      "integrity": "sha1-ogCTVlbW9fa8TcdQLhrstwMihBY=",
+      "dev": true
     },
     "inflight": {
       "version": "1.0.6",
@@ -3721,7 +3728,8 @@
     "is-bluebird": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-bluebird/-/is-bluebird-1.0.2.tgz",
-      "integrity": "sha1-CWQ5Bg9KpBGr7hkUOoTWpVNG1uI="
+      "integrity": "sha1-CWQ5Bg9KpBGr7hkUOoTWpVNG1uI=",
+      "dev": true
     },
     "is-buffer": {
       "version": "1.1.6",
@@ -4613,12 +4621,8 @@
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
-    },
-    "lodash.clonedeep": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "dev": true
     },
     "lodash.sortby": {
       "version": "4.7.0",
@@ -4772,12 +4776,14 @@
     "moment": {
       "version": "2.26.0",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.26.0.tgz",
-      "integrity": "sha512-oIixUO+OamkUkwjhAVE18rAMfRJNsNe/Stid/gwHSOfHrOtw9EhAY2AHvdKZ/k/MggcYELFCJz/Sn2pL8b8JMw=="
+      "integrity": "sha512-oIixUO+OamkUkwjhAVE18rAMfRJNsNe/Stid/gwHSOfHrOtw9EhAY2AHvdKZ/k/MggcYELFCJz/Sn2pL8b8JMw==",
+      "dev": true
     },
     "moment-timezone": {
       "version": "0.5.31",
       "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.31.tgz",
       "integrity": "sha512-+GgHNg8xRhMXfEbv81iDtrVeTcWt0kWmTEY1XQK14dICTXnWJnT0dxdlPspwqF3keKMVPXwayEsk1DI0AA/jdA==",
+      "dev": true,
       "requires": {
         "moment": ">= 2.9.0"
       }
@@ -4785,7 +4791,8 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
     },
     "mute-stream": {
       "version": "0.0.8",
@@ -5906,6 +5913,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/retry-as-promised/-/retry-as-promised-3.2.0.tgz",
       "integrity": "sha512-CybGs60B7oYU/qSQ6kuaFmRd9sTZ6oXSc0toqePvV74Ac6/IFZSI1ReFQmtCN+uvW1Mtqdwpvt/LGOiCBAY2Mg==",
+      "dev": true,
       "requires": {
         "any-promise": "^1.3.0"
       }
@@ -6120,12 +6128,14 @@
     "semver": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true
     },
     "sequelize": {
       "version": "5.21.13",
       "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-5.21.13.tgz",
       "integrity": "sha512-wpwSpxzvADmgPkcOGeer5yFdAVsYeA7NLEw4evSXw03OlGL41J4S8hVz2/nilSWlJSwumlDGC9QbdwAmkWGqJg==",
+      "dev": true,
       "requires": {
         "bluebird": "^3.5.0",
         "cls-bluebird": "^2.1.0",
@@ -6147,7 +6157,8 @@
     "sequelize-pool": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/sequelize-pool/-/sequelize-pool-2.3.0.tgz",
-      "integrity": "sha512-Ibz08vnXvkZ8LJTiUOxRcj1Ckdn7qafNZ2t59jYHMX1VIebTAOYefWdRYFt6z6+hy52WGthAHAoLc9hvk3onqA=="
+      "integrity": "sha512-Ibz08vnXvkZ8LJTiUOxRcj1Ckdn7qafNZ2t59jYHMX1VIebTAOYefWdRYFt6z6+hy52WGthAHAoLc9hvk3onqA==",
+      "dev": true
     },
     "set-blocking": {
       "version": "2.0.0",
@@ -6203,7 +6214,8 @@
     "shimmer": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
-      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
+      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==",
+      "dev": true
     },
     "signal-exit": {
       "version": "3.0.3",
@@ -6806,7 +6818,8 @@
     "toposort-class": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toposort-class/-/toposort-class-1.0.1.tgz",
-      "integrity": "sha1-f/0feMi+KMO6Rc1OGj9e4ZO9mYg="
+      "integrity": "sha1-f/0feMi+KMO6Rc1OGj9e4ZO9mYg=",
+      "dev": true
     },
     "tough-cookie": {
       "version": "3.0.1",
@@ -7005,7 +7018,8 @@
     "uuid": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "dev": true
     },
     "v8-compile-cache": {
       "version": "2.1.1",
@@ -7045,7 +7059,8 @@
     "validator": {
       "version": "10.11.0",
       "resolved": "https://registry.npmjs.org/validator/-/validator-10.11.0.tgz",
-      "integrity": "sha512-X/p3UZerAIsbBfN/IwahhYaBbY68EN/UQBWHtsbXGT5bfrH/p4NQzUCG1kF/rtKaNpnJ7jAu6NGTdSNtyNIXMw=="
+      "integrity": "sha512-X/p3UZerAIsbBfN/IwahhYaBbY68EN/UQBWHtsbXGT5bfrH/p4NQzUCG1kF/rtKaNpnJ7jAu6NGTdSNtyNIXMw==",
+      "dev": true
     },
     "verror": {
       "version": "1.10.0",
@@ -7186,6 +7201,7 @@
       "version": "0.4.8",
       "resolved": "https://registry.npmjs.org/wkx/-/wkx-0.4.8.tgz",
       "integrity": "sha512-ikPXMM9IR/gy/LwiOSqWlSL3X/J5uk9EO2hHNRXS41eTLXaUFEVw9fn/593jW/tE5tedNg8YjT5HkCa4FqQZyQ==",
+      "dev": true,
       "requires": {
         "@types/node": "*"
       }

--- a/package.json
+++ b/package.json
@@ -1,14 +1,18 @@
 {
   "name": "sequelize-use-cache",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "caching sequelize result using redis",
   "main": "lib/index.js",
   "scripts": {
     "build": "npm test && babel src --out-dir lib --verbose",
     "lint": "eslint src",
     "jest": "jest .",
-    "test": "npm run lint && npm run jest"
+    "test": "npm run lint && npm run jest",
+    "prepublishOnly": "npm run build"
   },
+  "pre-commit": [
+    "test"
+  ],
   "author": "KimDongMin <dkrahd12@gmail.com> (https://github.com/haracejacob)",
   "license": "MIT",
   "jest": {
@@ -37,10 +41,7 @@
     "mariadb",
     "sqlite"
   ],
-  "dependencies": {
-    "lodash.clonedeep": "^4.5.0",
-    "sequelize": "^5.21.13"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@babel/cli": "^7.10.1",
     "@babel/core": "^7.10.2",
@@ -49,6 +50,7 @@
     "eslint-plugin-jest": "^23.13.2",
     "jest": "^26.0.1",
     "redis": "^3.0.2",
+    "sequelize": "^5.21.13",
     "sqlite3": "^4.2.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,35 +1,12 @@
 import { promisify } from 'util'
-import Sequelize from 'sequelize'
 import crypto from 'crypto'
-import cloneDeep from 'lodash.clonedeep'
-
-const methods = {
-  findOne: {
-    optionsIdx: 0,
-  },
-  findAll: {
-    optionsIdx: 0,
-  },
-  max: {
-    optionsIdx: 1,
-  },
-  min: {
-    optionsIdx: 1,
-  },
-  sum: {
-    optionsIdx: 1,
-  },
-  count: {
-    optionsIdx: 0,
-  },
-  // findAndCountAll === findAll + count
-  // findByPk === findOne
-}
 
 export default function useCache (sequelize, redis) {
   const asyncRedisGet = promisify(redis.get).bind(redis)
   const asyncRedisSet = promisify(redis.set).bind(redis)
-  const queryGenerator = sequelize.getQueryInterface().QueryGenerator
+
+  const SELECT = 'SELECT'
+  const originalQueryMethod = sequelize.query.bind(sequelize)
 
   const getFromCache = async (key, model, { raw }) => {
     const res = await asyncRedisGet(key)
@@ -61,80 +38,45 @@ export default function useCache (sequelize, redis) {
     await asyncRedisSet(...redisArgs)
   }
 
-  const fetchFromDatabase = async (key, method, ...args) => {
-    const results = await method(...args)
+  const fetchFromDatabase = async (key, sql, options) => {
+    const results = await originalQueryMethod(sql, options)
 
-    const options = args[0]
     setCache(key, results, options)
 
     return results
   }
 
-  const generateSelectQuery = (model, options) => {
-    if (options.include) {
-      if (!Array.isArray(options.include)) {
-        options.include = [options.include]
-      }
-      const tableNames = {}
-      tableNames[model.getTableName(options)] = true
-
-      options.hasJoin = true
-      model._validateIncludedElements(options, tableNames)
-    }
-    Sequelize.Utils.mapFinderOptions(options, model)
-
-    return queryGenerator.selectQuery(
-      model.tableName,
-      options,
-      model
-    )
-  }
-
   const keyPrefix = 'sequelize-use-cache'
-  const generateKey = ({ model, method, options }) => {
-    const stmt = generateSelectQuery(model, cloneDeep(options))
-    const tableName = model.tableName
+  const generateKey = (sql, model) => {
 
+    const tableName = model && model.tableName || ''
     const hash = crypto
       .createHash('sha256')
-      .update(stmt)
+      .update(sql)
       .digest('hex')
 
-    return `${keyPrefix}:${tableName}:${method.name}:${hash}`
+    return `${keyPrefix}:${tableName}:${hash}`
   }
 
-  const fetchFromCache = async (model, method, ...args) => {
-    const options = args[0]
-    const key = generateKey({
-      model,
-      method,
-      options,
-    })
+  const fetchFromCache = async (sql, options) => {
+    const { model } = options
+
+    const key = generateKey(sql, model)
 
     const res = await getFromCache(key, model, options)
     if (res) {
-      model.cacheHit = true
+      sequelize.cacheHit = true
       return res
     }
-    model.cacheHit = false
-    return await fetchFromDatabase(key, method, ...args)
+    sequelize.cacheHit = false
+    return await fetchFromDatabase(key, sql, options)
   }
 
-  const modelNames = Object.keys(sequelize.models)
-  modelNames.forEach(modelName => {
-    const model = sequelize.models[modelName]
-    Object.entries(methods).map(([method, { optionsIdx }]) => {
-      const originalMethod = model[method].bind(model)
-
-      model[method] = async (...args) => {
-        const options = args[optionsIdx]
-
-        if (options && options.cache) {
-          return await fetchFromCache(model, originalMethod, ...args)
-        }
-        model.cacheHit = undefined
-        return await originalMethod(...args)
-      }
-    })
-  })
+  sequelize.query = async (sql, options) => {
+    if (options.type === SELECT && options.cache) {
+      return await fetchFromCache(sql, options)
+    }
+    sequelize.cacheHit = undefined
+    return await originalQueryMethod(sql, options)
+  }
 }


### PR DESCRIPTION
### Design intention
Immediately after publishing the package, the version has upgraded to v2.
When I first designed `sequelize-use-cache`, I thought it would be better to cache the query results by proxying the Select methods (`findOne, findAll, count ...`). The problem, However, is that to create the redis key, i need to create SQL using the model and options, and to do that, i need to take the code from the sequelize module intact.
`sequelize.query` was an ideal method because the sql, already generated, and options were used as arguments and was called unconditionally to execute a query. So I modified the code to proxyed it.

### pros
* Enable to caching all select query

### cons
* `model.cacheHit` is deprecated (use `sequelize.cacheHit`)
